### PR TITLE
make build productions binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 GO = go
 SCDOC = scdoc
+LDFLAG = "-ldflags \"-s -w\" "
 
 pkgs = $(shell $(GO) list ./... | grep -v /vendor/)
 
@@ -23,8 +24,10 @@ test: fmt
 
 .PHONY: all clean docs
 
+
 binaries: linux windows
 linux:
-		GOOS=linux ${GO} build -o bin/shoelaces -ldflags "-s -w"
+		GOOS=linux ${GO} build -o bin/shoelaces ${LDFLAG}
 windows:
-		GOOS=windows ${GO} build -o bin/shoelaces.exe -ldflags "-s -w"
+		GOOS=windows ${GO} build -o bin/shoelaces.exe ${LDFLAG}
+	

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO = go
 SCDOC = scdoc
-LDFLAG = "-ldflags \"-s -w\" "
+LDFLAG = "-s -w"
 
 pkgs = $(shell $(GO) list ./... | grep -v /vendor/)
 
@@ -27,7 +27,8 @@ test: fmt
 
 binaries: linux windows
 linux:
-		GOOS=linux ${GO} build -o bin/shoelaces ${LDFLAG}
+		GOOS=linux ${GO} build -o bin/shoelaces --ldflag "${LDFLAG}"
 windows:
-		GOOS=windows ${GO} build -o bin/shoelaces.exe ${LDFLAG}
+		GOOS=windows ${GO} build -o bin/shoelaces.exe --ldflag "${LDFLAG}"
+
 	

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ test: fmt
 
 .PHONY: all clean docs
 
-binarys: linux windows
+binaries: linux windows
 linux:
 		GOOS=linux ${GO} build -o bin/shoelaces -ldflags "-s -w"
 windows:

--- a/Makefile
+++ b/Makefile
@@ -24,11 +24,8 @@ test: fmt
 
 .PHONY: all clean docs
 
-
 binaries: linux windows
 linux:
-		GOOS=linux ${GO} build -o bin/shoelaces --ldflag "${LDFLAG}"
+		GOOS=linux ${GO} build -o bin/shoelaces -ldflags ${LDFLAG}
 windows:
-		GOOS=windows ${GO} build -o bin/shoelaces.exe --ldflag "${LDFLAG}"
-
-	
+		GOOS=windows ${GO} build -o bin/shoelaces.exe -ldflags ${LDFLAG}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GO = go
 SCDOC = scdoc
-LDFLAG = "-s -w"
+LDFLAGS = "-s -w"
 
 pkgs = $(shell $(GO) list ./... | grep -v /vendor/)
 
@@ -26,6 +26,6 @@ test: fmt
 
 binaries: linux windows
 linux:
-		GOOS=linux ${GO} build -o bin/shoelaces -ldflags ${LDFLAG}
+		GOOS=linux ${GO} build -o bin/shoelaces -ldflags ${LDFLAGS}
 windows:
-		GOOS=windows ${GO} build -o bin/shoelaces.exe -ldflags ${LDFLAG}
+		GOOS=windows ${GO} build -o bin/shoelaces.exe -ldflags ${LDFLAGS}

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,9 @@ test: fmt
 			./test/integ-test/integ_test.py
 
 .PHONY: all clean docs
+
+binarys: linux windows
+linux:
+		GOOS=linux ${GO} build -o bin/shoelaces -ldflags "-s -w"
+windows:
+		GOOS=windows ${GO} build -o bin/shoelaces.exe -ldflags "-s -w"


### PR DESCRIPTION
Added building of PRD binaries that is smaller and can be used to deploy to a server.
To prevent installing full go stack on a server and have an easy way of building binaries for other systems on my local workstation without looking up these commands.