### PR TITLE
Dockerfile: Add docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.15-alpine AS build
+
+WORKDIR /shoelaces
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-s -w -extldflags "-static"' -o /tmp/shoelaces . && \
+printf "---\nnetworkMaps:\n" > /tmp/mappings.yaml
+
+# Final container has basically nothing in it but the executable
+FROM scratch
+COPY --from=build /tmp/shoelaces /shoelaces
+
+WORKDIR /data
+COPY --from=build /tmp/mappings.yaml mappings.yaml
+COPY --from=build /shoelaces/web /web
+ENV DOMAIN=0.0.0.0
+ENV PORT=8081
+ENTRYPOINT ["/shoelaces"]
+CMD ["-data-dir", "/data", "-static-dir", "/web"]


### PR DESCRIPTION
This is based on #7 and should be applied after that.  If there's a desire for it I can set this up to be compatible with docker buildx, but as my use case only requires x86 images, I did not pursue that initially.