### PR TITLE
No extra poll in ipxemenu

### DIFF
--- a/internal/handlers/ipxemenu.go
+++ b/internal/handlers/ipxemenu.go
@@ -23,7 +23,6 @@ import (
 )
 
 const menuHeader = "#!ipxe\n" +
-	"chain /poll/1/${netX/mac:hexhyp}\n" +
 	"menu Choose target to boot\n"
 
 const menuFooter = "\n" +


### PR DESCRIPTION
Removed 'chain  /poll/1/${netX/mac:hexhyp}' from the ipxemenu entry. To make it possible that pressing Ctrl-B gets user immediately to the desired menu.