### PR TITLE
String changes in internal/polling/polling.go

### DIFF
--- a/internal/polling/polling.go
+++ b/internal/polling/polling.go
@@ -42,16 +42,22 @@ const (
 		"#\n" +
 		"# Do\n" +
 		"#    curl http://{{.baseURL}}/poll/1/06-66-de-ad-be-ef\n" +
-		"# to get an idea about what iPXE will receive.\n"
+		"# to get an idea about what the iPXE client will receive.\n"
 
 	maxRetry = 10
 
 	retryScript = "#!ipxe\n" +
-		"prompt --key 0x02 --timeout 10000 shoelaces: Press Ctrl-B for manual override... && " +
-		"chain -ar http://{{.baseURL}}/ipxemenu || " +
-		"chain -ar http://{{.baseURL}}/poll/1/{{.macAddress}}\n"
+		"prompt --key 0x02 --timeout 7000 shoelaces: Press Ctrl-B for manual override... \\\n" +
+		"  && chain -ar http://{{.baseURL}}/ipxemenu \\\n" +
+		"  || chain -ar http://{{.baseURL}}/poll/1/{{.macAddress}}\n" +
+		"#\n" +
+		"# FYI: For the iPXE client is the above an endless loop,\n" +
+		"#      but it is the shoelaces server that decides if it loops.\n"
 
 	timeoutScript = "#!ipxe\n" +
+		"echo\n" +
+		"echo Shoelaces is at maxRetry\n" +
+		"echo\n" +
 		"exit\n"
 
 	// BootAction is used when a user selects a script for the polling

--- a/internal/polling/polling.go
+++ b/internal/polling/polling.go
@@ -49,15 +49,13 @@ const (
 	retryScript = "#!ipxe\n" +
 		"prompt --key 0x02 --timeout 7000 shoelaces: Press Ctrl-B for manual override... \\\n" +
 		"  && chain -ar http://{{.baseURL}}/ipxemenu \\\n" +
-		"  || chain -ar http://{{.baseURL}}/poll/1/{{.macAddress}}\n" +
-		"#\n" +
-		"# FYI: For the iPXE client is the above an endless loop,\n" +
-		"#      but it is the shoelaces server that decides if it loops.\n"
+		"  || chain -ar http://{{.baseURL}}/poll/1/{{.macAddress}}\n\n" +
+		"# Note: the iPXE client will see the above code as an endless loop.\n" +
+		"# However, Shoelaces will break that loop after a fixed number of retries.\n"
 
 	timeoutScript = "#!ipxe\n" +
 		"echo\n" +
-		"echo Shoelaces is at maxRetry\n" +
-		"echo\n" +
+		"echo Shoelaces reached the maximum number of retries\n" +
 		"exit\n"
 
 	// BootAction is used when a user selects a script for the polling

--- a/test/integ-test/expected-results/poll-unknown.txt
+++ b/test/integ-test/expected-results/poll-unknown.txt
@@ -2,6 +2,6 @@
 prompt --key 0x02 --timeout 7000 shoelaces: Press Ctrl-B for manual override... \
   && chain -ar http://localhost:18888/ipxemenu \
   || chain -ar http://localhost:18888/poll/1/06-66-de-ad-be-ef
-#
-# FYI: For the iPXE client is the above an endless loop,
-#      but it is the shoelaces server that decides if it loops.
+
+# Note: the iPXE client will see the above code as an endless loop.
+# However, Shoelaces will break that loop after a fixed number of retries.

--- a/test/integ-test/expected-results/poll-unknown.txt
+++ b/test/integ-test/expected-results/poll-unknown.txt
@@ -1,2 +1,7 @@
 #!ipxe
-prompt --key 0x02 --timeout 10000 shoelaces: Press Ctrl-B for manual override... && chain -ar http://localhost:18888/ipxemenu || chain -ar http://localhost:18888/poll/1/06-66-de-ad-be-ef
+prompt --key 0x02 --timeout 7000 shoelaces: Press Ctrl-B for manual override... \
+  && chain -ar http://localhost:18888/ipxemenu \
+  || chain -ar http://localhost:18888/poll/1/06-66-de-ad-be-ef
+#
+# FYI: For the iPXE client is the above an endless loop,
+#      but it is the shoelaces server that decides if it loops.

--- a/test/integ-test/expected-results/poll.txt
+++ b/test/integ-test/expected-results/poll.txt
@@ -1,2 +1,7 @@
 #!ipxe
-prompt --key 0x02 --timeout 10000 shoelaces: Press Ctrl-B for manual override... && chain -ar http://localhost:18888/ipxemenu || chain -ar http://localhost:18888/poll/1/ff-ff-ff-ff-ff-ff
+prompt --key 0x02 --timeout 7000 shoelaces: Press Ctrl-B for manual override... \
+  && chain -ar http://localhost:18888/ipxemenu \
+  || chain -ar http://localhost:18888/poll/1/ff-ff-ff-ff-ff-ff
+#
+# FYI: For the iPXE client is the above an endless loop,
+#      but it is the shoelaces server that decides if it loops.

--- a/test/integ-test/expected-results/poll.txt
+++ b/test/integ-test/expected-results/poll.txt
@@ -2,6 +2,6 @@
 prompt --key 0x02 --timeout 7000 shoelaces: Press Ctrl-B for manual override... \
   && chain -ar http://localhost:18888/ipxemenu \
   || chain -ar http://localhost:18888/poll/1/ff-ff-ff-ff-ff-ff
-#
-# FYI: For the iPXE client is the above an endless loop,
-#      but it is the shoelaces server that decides if it loops.
+
+# Note: the iPXE client will see the above code as an endless loop.
+# However, Shoelaces will break that loop after a fixed number of retries.


### PR DESCRIPTION
The most important one, from the point of view of human user, is the addition of telling that a maximum retry has been reached.

The poll script got rid of the way too long line. That is done by using "iPXE script continueing line character", \, backslash. Poll interval shorter, from ten seconds to seven seconds, also from 10000 ms to more readable 7000 ms (clearly three zeros (how many zeros are in 10000? (four or five?))).
Added information about a loop that only looks like a loop.

A minor  `s/iPXE/iPXE client/`.

In directory test/integ-test/expected-results/ are poll-unknown.txt and poll.txt updated for getting a clean `make test`.