### PR TITLE
Test start

### DIFF
--- a/test/integ-test/expected-results/start.txt
+++ b/test/integ-test/expected-results/start.txt
@@ -1,0 +1,9 @@
+#!ipxe
+echo Shoelaces starts polling
+chain --autofree --replace \
+    http://localhost:18888/poll/1/${netX/mac:hexhyp}
+#
+#
+# Do
+#    curl http://localhost:18888/poll/1/06-66-de-ad-be-ef
+# to get an idea about what iPXE will receive.

--- a/test/integ-test/integ_test.py
+++ b/test/integ-test/integ_test.py
@@ -106,6 +106,7 @@ REQUEST_RESPONSE_PAIRS = [("/static/", "static.html"),
                           ("/configs/static/", "configs-static-default.txt"),
                           ("/configs/static/rc.local-bootstrap",
                            "rc.local-bootstrap"),
+                          ("/start", "start.txt"),
                           ("/ipxemenu", "ipxemenu.txt")]
 
 


### PR DESCRIPTION
In commit 1c79728984af was endpoint '/start' added, now it is tested.

Signed-off-by: Geert Stappers <stappers@stappers.it>