### PR TITLE
Style: How client and server interact during poll

### DIFF
--- a/internal/polling/polling.go
+++ b/internal/polling/polling.go
@@ -51,7 +51,7 @@ const (
 		"  && chain -ar http://{{.baseURL}}/ipxemenu \\\n" +
 		"  || chain -ar http://{{.baseURL}}/poll/1/{{.macAddress}}\n\n" +
 		"# Note: the iPXE client will see the above code as an endless loop.\n" +
-		"# However, Shoelaces will break that loop after a fixed number of retries.\n"
+		"# However, Shoelaces server can break that loop to enable further booting.\n"
 
 	timeoutScript = "#!ipxe\n" +
 		"echo\n" +

--- a/test/integ-test/expected-results/poll-unknown.txt
+++ b/test/integ-test/expected-results/poll-unknown.txt
@@ -4,4 +4,4 @@ prompt --key 0x02 --timeout 7000 shoelaces: Press Ctrl-B for manual override... 
   || chain -ar http://localhost:18888/poll/1/06-66-de-ad-be-ef
 
 # Note: the iPXE client will see the above code as an endless loop.
-# However, Shoelaces will break that loop after a fixed number of retries.
+# However, Shoelaces server can break that loop to enable further booting.

--- a/test/integ-test/expected-results/poll.txt
+++ b/test/integ-test/expected-results/poll.txt
@@ -4,4 +4,4 @@ prompt --key 0x02 --timeout 7000 shoelaces: Press Ctrl-B for manual override... 
   || chain -ar http://localhost:18888/poll/1/ff-ff-ff-ff-ff-ff
 
 # Note: the iPXE client will see the above code as an endless loop.
-# However, Shoelaces will break that loop after a fixed number of retries.
+# However, Shoelaces server can break that loop to enable further booting.


### PR DESCRIPTION
The iPXE client just repeats the same request, a.k.a. "polling". It is the Shoelaces server that can break the polling loop. Either by handing out automated boot entry point based on IP address or DNS PTR record,  hand picked boot entry point from Web UI or due retry maximum reached.

Signed-off-by: Geert Stappers <stappers@stappers.it>