### PR TITLE
feat: support -v or -vv in integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ docs: shoelaces.8
 
 test: fmt
 		$(GO) test -v $(pkgs) && \
-			./test/integ-test/integ_test.py
+			./test/integ-test/integ_test.py -vv
 
 .PHONY: all clean docs
 

--- a/test/integ-test/integ_test.py
+++ b/test/integ-test/integ_test.py
@@ -214,4 +214,4 @@ def test_template_variables_list(shoelaces_instance, script, env, vars):
 
 
 if __name__ == "__main__":
-    pytest.main(args=['-v'], plugins=None)
+    pytest.main(args=sys.argv[1:], plugins=None)


### PR DESCRIPTION
I'm staying out of `argparse` to avoid the extra import.