### PR TITLE
Update FROM references in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine AS build
+FROM docker-te-base/base/go:1.15-alpine-linux-distroless AS build
 
 WORKDIR /shoelaces
 COPY . .
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-s -w -extldflags "-static"' 
 printf "---\nnetworkMaps:\n" > /tmp/mappings.yaml
 
 # Final container has basically nothing in it but the executable
-FROM scratch
+FROM docker-te-base/base/debian:null-linux-distroless
 COPY --from=build /tmp/shoelaces /shoelaces
 
 WORKDIR /data


### PR DESCRIPTION
## Summary
- Updated `Dockerfile` (line 10) from `scratch` to `docker-te-base/base/debian:null-linux-distroless` (Pattern not yet implemented)
- Updated `Dockerfile` (line 1) from `golang:1.15-alpine` to `docker-te-base/base/go:1.15-alpine-linux-distroless` (Pattern not yet implemented)

## Testing
- Not run (automated Dockerfile rewrite)