### PR TITLE
Replace io/ioutil with os equivalents

### DIFF
--- a/internal/environment/environment.go
+++ b/internal/environment/environment.go
@@ -17,7 +17,6 @@ package environment
 import (
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"net"
 	"os"
 	"path"
@@ -134,7 +133,7 @@ func (env *Environment) initStaticTemplates() {
 func (env *Environment) initEnvOverrides() []string {
 	var environments = make([]string, 0)
 	envPath := filepath.Join(env.DataDir, env.EnvDir)
-	files, err := ioutil.ReadDir(envPath)
+	files, err := os.ReadDir(envPath)
 	if err == nil {
 		for _, f := range files {
 			if f.IsDir() {

--- a/internal/handlers/static.go
+++ b/internal/handlers/static.go
@@ -16,7 +16,6 @@ package handlers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -76,17 +75,17 @@ func (o *OverlayFileServerHandler) ServeHTTP(w http.ResponseWriter, r *http.Requ
 	}
 
 	isDir := false
-	fileList := make(map[string]os.FileInfo)
+	fileList := make(map[string]os.DirEntry)
 
 	if errUpper == nil && infoUpper.IsDir() {
-		files, _ := ioutil.ReadDir(upper)
+		files, _ := os.ReadDir(upper)
 		for _, f := range files {
 			fileList[f.Name()] = f
 		}
 		isDir = true
 	}
 	if errLower == nil && infoLower.IsDir() {
-		files, _ := ioutil.ReadDir(lower)
+		files, _ := os.ReadDir(lower)
 		for _, f := range files {
 			if _, ok := fileList[f.Name()]; !ok {
 				fileList[f.Name()] = f

--- a/internal/ipxe/ipxescript.go
+++ b/internal/ipxe/ipxescript.go
@@ -15,7 +15,7 @@
 package ipxe
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -67,7 +67,7 @@ func appendScriptsFromDir(logger log.Logger, scripts []Script, templateExtension
 
 // scriptDirList returns the names of all available ipxe script templates
 func scriptDirList(logger log.Logger, templateExtension string, datadir string) []ScriptName {
-	files, err := ioutil.ReadDir(datadir)
+	files, err := os.ReadDir(datadir)
 	if err != nil {
 		logger.Info("list ipxe scripts failed", "component", "ipxescript", "dir", datadir, "err", err)
 		return nil

--- a/internal/mappings/parse.go
+++ b/internal/mappings/parse.go
@@ -15,7 +15,6 @@
 package mappings
 
 import (
-	"io/ioutil"
 	"os"
 
 	"gopkg.in/yaml.v3"
@@ -58,7 +57,7 @@ func ParseYamlMappings(logger log.Logger, mappingsFile string) *Mappings {
 	var mappings Mappings
 
 	logger.Info("reading mappings", "component", "config", "source", mappingsFile)
-	yamlFile, err := ioutil.ReadFile(mappingsFile)
+	yamlFile, err := os.ReadFile(mappingsFile)
 
 	if err != nil {
 		logger.Error("read mappings failed", "err", err)


### PR DESCRIPTION
ioutil.ReadFile and ioutil.ReadDir have been deprecated since Go 1.16.